### PR TITLE
adding a check for canvas.transferControlToOffscreen when determining whether workers can be used

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -1,10 +1,13 @@
 (function main(global, module, isWorker, workerSize) {
-  var canUseWorker = global.Worker &&
+  var canUseWorker = !!(
+    global.Worker &&
     global.Blob &&
-    global.OffscreenCanvas &&
     global.Promise &&
+    global.OffscreenCanvas &&
+    global.HTMLCanvasElement &&
+    global.HTMLCanvasElement.prototype.transferControlToOffscreen &&
     global.URL &&
-    !!global.URL.createObjectURL;
+    global.URL.createObjectURL);
 
   function noop() {}
 


### PR DESCRIPTION
#109 

In Safari on Mac and iOS, under "Experimental Features" , there is an "ImageBitmap and OffscreenCanvas" experiment. However, this implementation is incomplete. Among other things, it is missing the `transferControlToOffscreen` method. For now, if that is not available, we will not use the incomplete implementation.