### PR TITLE
fix typo in warning when web worker fails to launch

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -153,7 +153,7 @@
           worker = new Worker(URL.createObjectURL(new Blob([code])));
         } catch (e) {
           // eslint-disable-next-line no-console
-          typeof console !== undefined && typeof console.warn === 'function' ? console.warn('🎊 Count not load worker', e) : null;
+          typeof console !== undefined && typeof console.warn === 'function' ? console.warn('🎊 Could not load worker', e) : null;
 
           return null;
         }


### PR DESCRIPTION
Error message typo