### PR TITLE
Add Scalar Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The `confetti` parameter is a single optional `options` object, which has the fo
   - `origin.y` _Number (default: 0.5)_: The `y` position on the page, with `0` being the top edge and `1` being the bottom edge.
 - `colors` _Array&lt;String&gt;_: An array of color strings, in the HEX format... you know, like `#bada55`.
 - `shapes` _Array&lt;String&gt;_: An array of shapes for the confetti. The possible values are `square` and `circle`. The default is to use both shapes in an even mix. You can even change the mix by providing a value such as `['circle', 'circle', 'square']` to use two third circles and one third squares.
+- `scalar` _Number (default: 1)_: Scale factor for each confetti particle.
 - `zIndex` _Integer (default: 100)_: The confetti should be on top, after all. But if you have a crazy high page, you can set it even higher.
 - `disableForReducedMotion` _Boolean (default: false)_: Disables confetti entirely for users that [prefer reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion). The `confetti()` promise will resolve immediately in this case.
 

--- a/src/confetti.js
+++ b/src/confetti.js
@@ -187,7 +187,8 @@
       '#ff36ff'
     ],
     // probably should be true, but back-compat
-    disableForReducedMotion: false
+    disableForReducedMotion: false,
+    scalar: 1
   };
 
   function convert(val, transform) {
@@ -290,7 +291,8 @@
       wobbleX: 0,
       wobbleY: 0,
       gravity: opts.gravity * 3,
-      ovalScalar: 0.6
+      ovalScalar: 0.6,
+      scalar: opts.scalar
     };
   }
 
@@ -303,8 +305,8 @@
     fetti.tiltSin = Math.sin(fetti.tiltAngle);
     fetti.tiltCos = Math.cos(fetti.tiltAngle);
     fetti.random = Math.random() + 5;
-    fetti.wobbleX = fetti.x + (10 * Math.cos(fetti.wobble));
-    fetti.wobbleY = fetti.y + (10 * Math.sin(fetti.wobble));
+    fetti.wobbleX = fetti.x + ((10 * fetti.scalar) * Math.cos(fetti.wobble));
+    fetti.wobbleY = fetti.y + ((10 * fetti.scalar) * Math.sin(fetti.wobble));
 
     var progress = (fetti.tick++) / fetti.totalTicks;
 
@@ -419,6 +421,7 @@
       var colors = prop(options, 'colors');
       var ticks = prop(options, 'ticks', Number);
       var shapes = prop(options, 'shapes');
+      var scalar = prop(options, 'scalar');
       var origin = getOrigin(options);
 
       var temp = particleCount;
@@ -439,7 +442,8 @@
             shape: shapes[randomInt(0, shapes.length)],
             ticks: ticks,
             decay: decay,
-            gravity: gravity
+            gravity: gravity,
+            scalar: scalar
           })
         );
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -172,6 +172,21 @@ const uniqueColorsBySide = async (buffer) => {
   };
 };
 
+const totalPixels = async(buffer) => {
+  const image = await readImage(buffer);
+  let pixels = 0;
+  image.scan(0, 0, image.bitmap.width, image.bitmap.height, (x, y, idx) => {
+    const r = image.bitmap.data[idx + 0];
+    const g = image.bitmap.data[idx + 1];
+    const b = image.bitmap.data[idx + 2];
+
+    if (r === 255 && g === 255 && b === 255) { return; }
+
+    pixels++;
+  });
+  return pixels;
+};
+
 const removeOpacity = async (buffer) => {
   const image = await readImage(buffer);
   image.rgba(false).background(0xFFFFFFFF);
@@ -309,6 +324,37 @@ test('shoots circle confetti', async t => {
   const pixels = await uniqueColors(t.context.image);
 
   t.deepEqual(pixels, ['#0000ff', '#ffffff']);
+});
+
+test('shoots default scaled confetti', async t => {
+  const page = t.context.page = await fixturePage();
+
+  t.context.buffer = await confettiImage(page, {
+    colors: ['#0000ff'],
+    shapes: ['circle'],
+    particleCount: 10
+  });
+  t.context.image = await removeOpacity(t.context.buffer);
+
+  const pixels = await totalPixels(t.context.image);
+
+  t.is(pixels > 100, true);
+});
+
+test('shoots larger scaled confetti', async t => {
+  const page = t.context.page = await fixturePage();
+
+  t.context.buffer = await confettiImage(page, {
+    colors: ['#0000ff'],
+    shapes: ['circle'],
+    scalar: 2,
+    particleCount: 10
+  });
+  t.context.image = await removeOpacity(t.context.buffer);
+
+  const pixels = await totalPixels(t.context.image);
+
+  t.is(pixels > 500, true);
 });
 
 test('shoots confetti to the left', async t => {


### PR DESCRIPTION
Addresses https://github.com/catdad/canvas-confetti/issues/116

I didn't modify the math, as it seems to render fine to me even at larger sizes.

I also wasn't super sure how to test this since the rendering is not deterministic.  I went with raw pixel count as it seems to be relatively similar (+-30) across test runs.

Changes:

* add scalar option for sizing
* add size tests
* update readme