### PR TITLE
Prevent infinity loop when 'particleCount' is negative number.

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -206,6 +206,10 @@
     );
   }
 
+  function onlyPositiveInt(number){
+    return number < 0 ? 0 : Math.floor(number);
+  }
+
   function randomInt(min, max) {
     // [min, max)
     return Math.floor(Math.random() * (max - min)) + min;
@@ -412,7 +416,7 @@
     var animationObj;
 
     function fireLocal(options, size, done) {
-      var particleCount = prop(options, 'particleCount', Math.floor);
+      var particleCount = prop(options, 'particleCount', onlyPositiveInt);
       var angle = prop(options, 'angle', Number);
       var spread = prop(options, 'spread', Number);
       var startVelocity = prop(options, 'startVelocity', Number);


### PR DESCRIPTION
When 'particleCount' is negative number, while loop in this line 
`var temp = particleCount;
while (temp--)
`
it becomes infinite. So I suggest create only positive integer transform function and pass it instead Math.floor. 