### PR TITLE
Explicitly check for 2D OffscreenCanvas support

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -4,6 +4,7 @@
     global.Blob &&
     global.Promise &&
     global.OffscreenCanvas &&
+    global.OffscreenCanvasRenderingContext2D &&
     global.HTMLCanvasElement &&
     global.HTMLCanvasElement.prototype.transferControlToOffscreen &&
     global.URL &&


### PR DESCRIPTION
In Firefox you can enable "offscreen canvas" support in `about:config` which will make `OffscreenCanvas` available, but `getContext('2d')` will fail with a not implemented error since only WebGL offscreen canvases are supported.  This simply checks for the existence of `OffscreenCanvasRenderingContext2D` as well when determining whether offscreen canvases can be utilized. 