### PR TITLE
Defer worker creation

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -577,7 +577,21 @@
     return fire;
   }
 
-  module.exports = confettiCannon(null, { useWorker: true, resize: true });
+  // Make default export lazy to defer worker creation until called.
+  var defaultFire;
+  function getDefaultFire() {
+    if (!defaultFire) {
+      defaultFire = confettiCannon(null, { useWorker: true, resize: true });
+    }
+    return defaultFire;
+  }
+
+  module.exports = function() {
+    return getDefaultFire().apply(this, arguments);
+  };
+  module.exports.reset = function() {
+    getDefaultFire().reset();
+  };
   module.exports.create = confettiCannon;
 }((function () {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
Fixes #112, #131

Worker creation can be deferred until needed. This wraps the default export and reset functions, only creating the default fire function when needed. Same API as before, could be released as a patch.

An alternative is to move worker init into the fire function:
```js
function fire(options) {
  if (worker === undefined) {
    worker = shouldUseWorker ? getWorker() : null;
  }
```
This might be cleaner than the shim but would probably be more invasive so I didn't go there.