### PR TITLE
feat(): Support for half-circle shapes and multiple scalar values

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -190,7 +190,7 @@
     ],
     // probably should be true, but back-compat
     disableForReducedMotion: false,
-    scalar: 1
+    scalar: [1]
   };
 
   function convert(val, transform) {
@@ -457,7 +457,7 @@
             decay: decay,
             gravity: gravity,
             drift: drift,
-            scalar: scalar
+            scalar: scalar[randomInt(0, scalar.length)]
           })
         );
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -347,7 +347,7 @@ test('shoots larger scaled confetti', async t => {
   t.context.buffer = await confettiImage(page, {
     colors: ['#0000ff'],
     shapes: ['circle'],
-    scalar: 10,
+    scalar: [10],
     particleCount: 10
   });
   t.context.image = await removeOpacity(t.context.buffer);


### PR DESCRIPTION
Made a simple change to support half-circle shapes and also changed scalar to support multiple values for different sized confettis