### PR TITLE
Add contains check for canvas when removing

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -682,8 +682,10 @@
           global.removeEventListener('resize', onResize);
         }
 
-        if (isLibCanvas && canvas && document.body.contains(canvas)) {
-          document.body.removeChild(canvas);
+        if (isLibCanvas && canvas) {
+          if (document.body.contains(canvas)) {
+            document.body.removeChild(canvas); 
+          }
           canvas = null;
           initialized = false;
         }

--- a/src/confetti.js
+++ b/src/confetti.js
@@ -682,7 +682,7 @@
           global.removeEventListener('resize', onResize);
         }
 
-        if (isLibCanvas && canvas) {
+        if (isLibCanvas && canvas && document.body.contains(canvas)) {
           document.body.removeChild(canvas);
           canvas = null;
           initialized = false;


### PR DESCRIPTION
If we're running in a context where the current document.body has been switched, `done` will still try to remove the canvas from the new document.body, which will never work. This PR adds a check to ensure the canvas is contained within the body before removing it.